### PR TITLE
v1.2.0 with improvements of the BeginScope() method assertion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,41 @@ logger.SetupSequence()
     .EndScope();
 ```
 
+### Application Insights dictionary state
+If you use Application Insights as output of your logs, the `BeginScope()` state argument must take a dictionary of string/object as the following code sample:
+
+```
+using (this.logger.BeginScope(new Dictionary<string, object>() { { "Id", 1234 } }))
+{
+    ... // Other Log
+}
+```
+
+To assert the `BeginScope()` in the previous sample code, you can use the `SetupSequence().BeginScope(Object)` method assertion as pass the expected
+dictionary as argument.
+
+```csharp
+var logger = new LoggerMock<CustomerManager>();
+logger.SetupSequence()
+    .BeginScope(new Dictionary<string, object>() { { "Id", 1234 } })
+       ... // Other Log() assertions
+    .EndScope();
+```
+
+The [PosInformatique.Logging.Assertions](https://www.nuget.org/packages/PosInformatique.Logging.Assertions/) library provides a
+`SetupSequence().BeginScopeAsDictionary(Object)` method which allows to assert the content of the dictionary using an object (Each property and his value of the expected
+object is considered as a key/value couple of the dictionary). Do not hesitate to use anonymous object in your unit test to make the code more easy to read.
+
+The following example have the same behavior as the previous example, but is more easy to read by removing the dictionary instantiation and some extract brackets:
+
+```csharp
+var logger = new LoggerMock<CustomerManager>();
+logger.SetupSequence()
+    .BeginScopeAsDictionary(new { Id = 1234 })
+       ... // Other Log() assertions
+    .EndScope();
+```
+
 ## Assertion fail messages
 The [PosInformatique.Logging.Assertions](https://www.nuget.org/packages/PosInformatique.Logging.Assertions/) library
 try to make the assert fail messages the most easy to understand for the developers:

--- a/README.md
+++ b/README.md
@@ -289,7 +289,53 @@ logger.SetupSequence()
     ... // Continue the setup expected log sequence
 ```
 
-### Assertion fail messages
+### Test the BeginScope() state
+If you use the `BeginScope` method in your logging process, you can assert the content of state
+specified in argument using two methods.
+
+For example, to assert the following code:
+```
+using (this.logger.BeginScope(new StateInfo() { Id = 1234 }))
+{
+    ... // Other Log
+}
+```
+
+With the `StateInfo` class as simple like like that:
+```csharp
+public class StateInfo
+{
+    public int Id { get; set; }
+}
+```
+
+You can assert the `BeginScope()` method call using an anonymous object:
+
+```csharp
+var logger = new LoggerMock<CustomerManager>();
+logger.SetupSequence()
+    .BeginScope(new { Id = 1234 })
+       ... // Other Log() assertions
+    .EndScope();
+```
+
+> The `BeginScope()` assertion check the equivalence (property by property and not the reference itself)
+between the actual object in the code and the expected object in the assertion.
+
+Or you can assert the `BeginScope()` method call using a delegate if your state object is complex:
+
+```csharp
+var logger = new LoggerMock<CustomerManager>();
+logger.SetupSequence()
+    .BeginScope<State>(state =>
+    {
+        state.Id.Should().Be(1234);
+    })
+       ... // Other Log() assertions
+    .EndScope();
+```
+
+## Assertion fail messages
 The [PosInformatique.Logging.Assertions](https://www.nuget.org/packages/PosInformatique.Logging.Assertions/) library
 try to make the assert fail messages the most easy to understand for the developers:
 

--- a/src/Logging.Assertions/ILoggerMockSetupSequence.cs
+++ b/src/Logging.Assertions/ILoggerMockSetupSequence.cs
@@ -16,9 +16,11 @@ namespace PosInformatique.Logging.Assertions
         /// <summary>
         /// Expect the call to the <see cref="ILogger.BeginScope{TState}(TState)"/> method.
         /// </summary>
-        /// <param name="state">State instance of the <see cref="BeginScope(object)"/> method argument expected.</param>
+        /// <typeparam name="TState">Type of the state expected.</typeparam>
+        /// <param name="state">Delegate called to assert the content of the state when the
+        /// the <see cref="ILogger.BeginScope{TState}(TState)"/> is called.</param>
         /// <returns>The current <see cref="ILoggerMockSetupSequence"/> which allows to continue the setup of the <see cref="ILogger"/> method calls.</returns>
-        ILoggerMockSetupSequence BeginScope(object state);
+        ILoggerMockSetupSequence BeginScope<TState>(Action<TState> state);
 
         /// <summary>
         /// Expect the call to the <see cref="IDisposable.Dispose"/> method which represents the scope

--- a/src/Logging.Assertions/LoggerMockSetupSequenceExtensions.cs
+++ b/src/Logging.Assertions/LoggerMockSetupSequenceExtensions.cs
@@ -15,6 +15,18 @@ namespace PosInformatique.Logging.Assertions
     public static class LoggerMockSetupSequenceExtensions
     {
         /// <summary>
+        /// Expect the call to the <see cref="ILogger.BeginScope{TState}(TState)"/> method.
+        /// </summary>
+        /// <param name="sequence"><see cref="ILoggerMockSetupSequence"/> to setup the sequence.</param>
+        /// <param name="state">Expected state of the <see cref="ILogger.BeginScope{TState}(TState)"/> call. The state object actual and expected
+        /// are compared by equivalence (property by property) and not by instance.</param>
+        /// <returns>The current <see cref="ILoggerMockSetupSequence"/> which allows to continue the setup of the <see cref="ILogger"/> method calls.</returns>
+        public static ILoggerMockSetupSequence BeginScope(this ILoggerMockSetupSequence sequence, object state)
+        {
+            return sequence.BeginScope<object>(expectedState => state.Should().BeEquivalentTo(state));
+        }
+
+        /// <summary>
         /// Expect the call to the <see cref="ILogger.Log{TState}(LogLevel, EventId, TState, Exception?, Func{TState, Exception?, string})"/> method
         /// with a <see cref="LogLevel.Debug"/> log level.
         /// </summary>

--- a/src/Logging.Assertions/LoggerMockSetupSequenceExtensions.cs
+++ b/src/Logging.Assertions/LoggerMockSetupSequenceExtensions.cs
@@ -6,6 +6,7 @@
 
 namespace PosInformatique.Logging.Assertions
 {
+    using System.Collections.Generic;
     using FluentAssertions;
     using Microsoft.Extensions.Logging;
 
@@ -15,7 +16,7 @@ namespace PosInformatique.Logging.Assertions
     public static class LoggerMockSetupSequenceExtensions
     {
         /// <summary>
-        /// Expect the call to the <see cref="ILogger.BeginScope{TState}(TState)"/> method.
+        /// Expect the call to the <see cref="ILogger.BeginScope{TState}(TState)"/> method with the specified <paramref name="state"/> object.
         /// </summary>
         /// <param name="sequence"><see cref="ILoggerMockSetupSequence"/> to setup the sequence.</param>
         /// <param name="state">Expected state of the <see cref="ILogger.BeginScope{TState}(TState)"/> call. The state object actual and expected
@@ -24,6 +25,31 @@ namespace PosInformatique.Logging.Assertions
         public static ILoggerMockSetupSequence BeginScope(this ILoggerMockSetupSequence sequence, object state)
         {
             return sequence.BeginScope<object>(expectedState => state.Should().BeEquivalentTo(state));
+        }
+
+        /// <summary>
+        /// Expect the call to the <see cref="ILogger.BeginScope{TState}(TState)"/> method with a <see cref="Dictionary{TKey, TValue}"/>
+        /// of <see cref="string"/>/<see cref="object"/> represents by the <paramref name="state"/> object instance.
+        /// The dictionary is compared by all the public property of the specified <paramref name="state"/> object instance.
+        /// </summary>
+        /// <param name="sequence"><see cref="ILoggerMockSetupSequence"/> to setup the sequence.</param>
+        /// <param name="state">Expected state of the <see cref="ILogger.BeginScope{TState}(TState)"/> call. The properties of the expected object <paramref name="state"/>
+        /// is compared by a dictionary of <see cref="string"/>/<see cref="object"/> specified in the argument when calling the
+        /// <see cref="ILogger.BeginScope{TState}(TState)"/> method.</param>
+        /// <returns>The current <see cref="ILoggerMockSetupSequence"/> which allows to continue the setup of the <see cref="ILogger"/> method calls.</returns>
+        public static ILoggerMockSetupSequence BeginScopeAsDictionary(this ILoggerMockSetupSequence sequence, object state)
+        {
+            return sequence.BeginScope<IDictionary<string, object>>(expectedState =>
+            {
+                var actualState = new Dictionary<string, object>();
+
+                foreach (var property in state.GetType().GetProperties())
+                {
+                    actualState.Add(property.Name, property.GetValue(state));
+                }
+
+                actualState.Should().BeEquivalentTo(expectedState);
+            });
         }
 
         /// <summary>

--- a/src/Logging.Assertions/LoggerMockSetupSequenceExtensions.cs
+++ b/src/Logging.Assertions/LoggerMockSetupSequenceExtensions.cs
@@ -24,7 +24,7 @@ namespace PosInformatique.Logging.Assertions
         /// <returns>The current <see cref="ILoggerMockSetupSequence"/> which allows to continue the setup of the <see cref="ILogger"/> method calls.</returns>
         public static ILoggerMockSetupSequence BeginScope(this ILoggerMockSetupSequence sequence, object state)
         {
-            return sequence.BeginScope<object>(expectedState => state.Should().BeEquivalentTo(state));
+            return sequence.BeginScope<object>(expectedState => state.Should().BeEquivalentTo(expectedState));
         }
 
         /// <summary>

--- a/src/Logging.Assertions/Logging.Assertions.csproj
+++ b/src/Logging.Assertions/Logging.Assertions.csproj
@@ -10,21 +10,24 @@
     <PackageProjectUrl>https://github.com/PosInformatique/PosInformatique.Logging.Assertions</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
-	  1.1.0
-      - Add the support to assert the log message template and the parameters.
-	  
-	  1.0.3
-      - Use FluentAssertions 6.0.0 library.
-	  
-      1.0.2
-      - The library target the .NET Standard 2.0 instead of .NET 6.0.
-      
-      1.0.1
-      - Various fixes for the NuGet package description.
+		1.2.0
+		- Improve the BeginScope() to use a delegate to assert complex state objects.
+		
+		1.1.0
+		- Add the support to assert the log message template and the parameters.
 
-      1.0.0
-      - Initial version
-    </PackageReleaseNotes>
+		1.0.3
+		- Use FluentAssertions 6.0.0 library.
+
+		1.0.2
+		- The library target the .NET Standard 2.0 instead of .NET 6.0.
+
+		1.0.1
+		- Various fixes for the NuGet package description.
+
+		1.0.0
+		- Initial version
+	</PackageReleaseNotes>
     <PackageTags>logger log fluent unittest assert assertions logging mock</PackageTags>
   </PropertyGroup>
 	

--- a/src/Logging.Assertions/Logging.Assertions.csproj
+++ b/src/Logging.Assertions/Logging.Assertions.csproj
@@ -12,6 +12,7 @@
     <PackageReleaseNotes>
 		1.2.0
 		- Improve the BeginScope() to use a delegate to assert complex state objects.
+		- Add a BeginScopeAsDictionary() method to check the state as dictionary string/object (useful for Application Insights logs).
 		
 		1.1.0
 		- Add the support to assert the log message template and the parameters.

--- a/tests/Logging.Assertions.Tests/LoggerMockTest.cs
+++ b/tests/Logging.Assertions.Tests/LoggerMockTest.cs
@@ -342,7 +342,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         }
 
         [Fact]
-        public void VerifyAllLogs_WithScopes()
+        public void VerifyAllLogs_WithScopes_ObjectAssertion()
         {
             var logger = new LoggerMock<ObjectToLog>();
             logger.SetupSequence()
@@ -361,6 +361,54 @@ namespace PosInformatique.Logging.Assertions.Tests
             objectToLog.InvokeWithScope();
 
             logger.VerifyLogs();
+        }
+
+        [Fact]
+        public void VerifyAllLogs_WithScopes_DelegateAssertion()
+        {
+            var logger = new LoggerMock<ObjectToLog>();
+            logger.SetupSequence()
+                .LogTrace("Log Trace 1")
+                .BeginScope<State>(state =>
+                {
+                    state.ScopeLevel.Should().Be(1);
+                    state.ScopeName.Should().Be("Scope level 1");
+                })
+                    .LogDebug("Log Debug 2")
+                    .BeginScope<State>(state =>
+                    {
+                        state.ScopeLevel.Should().Be(2);
+                        state.ScopeName.Should().Be("Scope level 2");
+                    })
+                        .LogInformation("Log Information 3")
+                    .EndScope()
+                    .LogWarning("Log Warning 4")
+                .EndScope()
+                .LogError("Log Error 5");
+
+            var objectToLog = new ObjectToLog(logger.Object);
+
+            objectToLog.InvokeWithScope();
+
+            logger.VerifyLogs();
+        }
+
+        [Fact]
+        public void VerifyAllLogs_WithScopes_DelegateAssertion_WrongExpectedStateType()
+        {
+            var logger = new LoggerMock<ObjectToLog>();
+            logger.SetupSequence()
+                .LogTrace("Log Trace 1")
+                .BeginScope<DateTime>(state =>
+                {
+                    throw new XunitException("Must not be called");
+                });
+
+            var objectToLog = new ObjectToLog(logger.Object);
+
+            objectToLog.Invoking(o => o.InvokeWithScope())
+                .Should().ThrowExactly<XunitException>()
+                .WithMessage("The 'BeginScope()' has been called with a wrong state argument type (Expected: DateTime, Actual: State).");
         }
 
         [Fact]
@@ -451,6 +499,13 @@ namespace PosInformatique.Logging.Assertions.Tests
             logger.VerifyLogs();
         }
 
+        private class State
+        {
+            public int ScopeLevel { get; set; }
+
+            public string? ScopeName { get; set; }
+        }
+
         private class ObjectToLog
         {
             private readonly ILogger<ObjectToLog> logger;
@@ -505,11 +560,11 @@ namespace PosInformatique.Logging.Assertions.Tests
             {
                 this.logger.LogTrace("Log Trace {0}", 1);
 
-                using (var scope1 = this.logger.BeginScope(new { ScopeLevel = 1, ScopeName = "Scope level 1" }))
+                using (var scope1 = this.logger.BeginScope(new State { ScopeLevel = 1, ScopeName = "Scope level 1" }))
                 {
                     this.logger.LogDebug("Log Debug {0}", 2);
 
-                    using (var scope2 = this.logger.BeginScope(new { ScopeLevel = 2, ScopeName = "Scope level 2" }))
+                    using (var scope2 = this.logger.BeginScope(new State { ScopeLevel = 2, ScopeName = "Scope level 2" }))
                     {
                         this.logger.LogInformation("Log Information {0}", 3);
                     }

--- a/tests/Logging.Assertions.Tests/LoggerMockTest.cs
+++ b/tests/Logging.Assertions.Tests/LoggerMockTest.cs
@@ -434,6 +434,21 @@ namespace PosInformatique.Logging.Assertions.Tests
         }
 
         [Fact]
+        public void BeginScope_AnonymousObjectAssertion_DifferentProperty()
+        {
+            var logger = new LoggerMock<ObjectToLog>();
+            logger.SetupSequence()
+                .LogTrace("Log Trace 1")
+                .BeginScope(new { DifferentProperty = "Other value" });
+
+            var objectToLog = new ObjectToLog(logger.Object);
+
+            objectToLog.Invoking(o => o.InvokeWithScopeAsAnonymousObject())
+                .Should().ThrowExactly<XunitException>()
+                .And.Message.StartsWith("Expectation has property state.ScopeLevel that the other object does not have.\r\nExpectation has property state.ScopeName that the other object does not have.");
+        }
+
+        [Fact]
         public void BeginScope_Expected()
         {
             var logger = new LoggerMock<ObjectToLog>();
@@ -470,7 +485,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         }
 
         [Fact]
-        public void BeginScope_Dictionary_ExpectedMissingProperty()
+        public void BeginScopeAsDictionary_ExpectedMissingProperty()
         {
             var logger = new LoggerMock<ObjectToLog>();
             logger.SetupSequence()
@@ -485,7 +500,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         }
 
         [Fact]
-        public void BeginScope_Dictionary_ExpectedLessProperties()
+        public void BeginScopeAsDictionary_ExpectedLessProperties()
         {
             var logger = new LoggerMock<ObjectToLog>();
             logger.SetupSequence()
@@ -617,6 +632,25 @@ namespace PosInformatique.Logging.Assertions.Tests
                     this.logger.LogDebug("Log Debug {0}", 2);
 
                     using (var scope2 = this.logger.BeginScope(new State { ScopeLevel = 2, ScopeName = "Scope level 2" }))
+                    {
+                        this.logger.LogInformation("Log Information {0}", 3);
+                    }
+
+                    this.logger.LogWarning("Log Warning {0}", 4);
+                }
+
+                this.logger.LogError("Log Error {0}", 5);
+            }
+
+            public void InvokeWithScopeAsAnonymousObject()
+            {
+                this.logger.LogTrace("Log Trace {0}", 1);
+
+                using (var scope1 = this.logger.BeginScope(new { ScopeLevel = 1, ScopeName = "Scope level 1" }))
+                {
+                    this.logger.LogDebug("Log Debug {0}", 2);
+
+                    using (var scope2 = this.logger.BeginScope(new { ScopeLevel = 2, ScopeName = "Scope level 2" }))
                     {
                         this.logger.LogInformation("Log Information {0}", 3);
                     }


### PR DESCRIPTION
- Update the BeginScope() to use a delegate (resolve #7).
- Add a BeginScopeAsDictionary() method to compare an object with a dictionary for the state object (resolve #8).
