### PR TITLE
v1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,26 @@ try to make the assert fail messages the most easy to understand for the develop
 ![Assertion Failed Too Many Calls](https://raw.githubusercontent.com/PosInformatique/PosInformatique.Logging.Assertions/main/docs/AssertionFailedTooManyCalls.png)
 ![Assertion Missing Logs](https://raw.githubusercontent.com/PosInformatique/PosInformatique.Logging.Assertions/main/docs/AssertionMissingLogs.png)
 
+## Non generic support of the ILogger interface
+The [PosInformatique.Logging.Assertions](https://www.nuget.org/packages/PosInformatique.Logging.Assertions/) library
+allows to mock the `ILogger<T>` and `ILogger` interfaces.
+
+To mock a `ILogger<T>` implementation use the following code:
+```csharp
+var logger = new LoggerMock<CustomerManager>();
+logger.SetupSequence()
+    .LogInformation("...");
+```
+
+To mock a `ILogger` implementation use the following code:
+```csharp
+var logger = new LoggerMock();
+logger.SetupSequence()
+    .LogInformation("...");
+```
+
+Both usage offers the same fluent assertion methods.
+
 ## Library dependencies
 - The [PosInformatique.Logging.Assertions](https://www.nuget.org/packages/PosInformatique.Logging.Assertions/) target the .NET Standard 2.0
 and the version 2.0.0 of the [Microsoft.Extensions.Logging.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions) NuGet package. So this library can be used with

--- a/build/azure-pipelines-release.yaml
+++ b/build/azure-pipelines-release.yaml
@@ -2,7 +2,7 @@ parameters:
 - name: VersionPrefix
   displayName: The version of the library
   type: string
-  default: 1.0.0
+  default: 1.4.0
 - name: VersionSuffix
   displayName: The version suffix of the library (rc.1). Use a space ' ' if no suffix.
   type: string

--- a/src/Logging.Assertions/ExceptionHelper.cs
+++ b/src/Logging.Assertions/ExceptionHelper.cs
@@ -1,0 +1,28 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ExceptionHelper.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.Logging.Assertions
+{
+    using System.Reflection;
+    using System.Runtime.InteropServices;
+
+    internal static class ExceptionHelper
+    {
+        private static readonly MethodInfo GetExceptionPointersMethod = typeof(Marshal).GetMethod("GetExceptionPointers");
+
+        public static bool IsExceptionOnGoing()
+        {
+            var ptr = (IntPtr)GetExceptionPointersMethod.Invoke(null, null);
+
+            if (ptr == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Logging.Assertions/LoggerMock.cs
+++ b/src/Logging.Assertions/LoggerMock.cs
@@ -186,9 +186,13 @@ namespace PosInformatique.Logging.Assertions
 
                 public void Dispose()
                 {
-                    this.recorder.GetCurrentExpectedLogAction<ExpectedLogEndScope>("Dispose()");
+                    // If an exception is ongoing, we don't thrown an exception an let the original exception propagated. 
+                    if (!ExceptionHelper.IsExceptionOnGoing())
+                    {
+                        this.recorder.GetCurrentExpectedLogAction<ExpectedLogEndScope>("Dispose()");
 
-                    this.recorder.mock.expectedLogActionsIndex++;
+                        this.recorder.mock.expectedLogActionsIndex++;
+                    }
                 }
             }
         }

--- a/src/Logging.Assertions/LoggerMock.cs
+++ b/src/Logging.Assertions/LoggerMock.cs
@@ -186,7 +186,7 @@ namespace PosInformatique.Logging.Assertions
 
                 public void Dispose()
                 {
-                    // If an exception is ongoing, we don't thrown an exception an let the original exception propagated. 
+                    // If an exception is ongoing, we don't thrown an exception an let the original exception propagated.
                     if (!ExceptionHelper.IsExceptionOnGoing())
                     {
                         this.recorder.GetCurrentExpectedLogAction<ExpectedLogEndScope>("Dispose()");

--- a/src/Logging.Assertions/LoggerMock.cs
+++ b/src/Logging.Assertions/LoggerMock.cs
@@ -6,8 +6,6 @@
 
 namespace PosInformatique.Logging.Assertions
 {
-    using System.Diagnostics.CodeAnalysis;
-    using System.Net.NetworkInformation;
     using FluentAssertions;
     using FluentAssertions.Common;
     using Microsoft.Extensions.Logging;
@@ -26,26 +24,25 @@ namespace PosInformatique.Logging.Assertions
     ///         calls to the <see cref="ILogger"/> methods.</item>
     /// </list>
     /// </summary>
-    /// <typeparam name="TCategoryName">The category name of the <see cref="ILogger{TCategoryName}"/> to create.</typeparam>
-    public sealed class LoggerMock<TCategoryName>
+    public class LoggerMock
     {
         private readonly IList<ExpectedLogAction> expectedLogActions;
 
         private int expectedLogActionsIndex;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LoggerMock{TCategoryName}"/> class.
+        /// Initializes a new instance of the <see cref="LoggerMock"/> class.
         /// </summary>
         public LoggerMock()
         {
             this.expectedLogActions = new List<ExpectedLogAction>();
-            this.Object = new LoggerRecorder(this);
+            this.Object = this.CreateRecorder<object>();
         }
 
         /// <summary>
-        /// Gets the mocked instance of the <see cref="ILogger{TCategoryName}"/>.
+        /// Gets the mocked instance of the <see cref="ILogger"/>.
         /// </summary>
-        public ILogger<TCategoryName> Object { get; }
+        public ILogger Object { get; }
 
         /// <summary>
         /// Entry method which allows to setup the sequence of the expected <see cref="ILogger"/> method calls.
@@ -70,11 +67,21 @@ namespace PosInformatique.Logging.Assertions
             }
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="LoggerRecorder{TCategoryName}"/> to record <see cref="ILogger"/> trace.
+        /// </summary>
+        /// <typeparam name="TCategoryName">Type of the category name to use for <see cref="ILogger{TCategoryName}"/>.</typeparam>
+        /// <returns>An instance of <see cref="LoggerRecorder{TCategoryName}"/> to record <see cref="ILogger"/> trace.</returns>
+        private protected virtual ILogger CreateRecorder<TCategoryName>()
+        {
+            return new LoggerRecorder<TCategoryName>(this);
+        }
+
         private sealed class LoggerMockSetupSequence : ILoggerMockSetupSequence
         {
-            private readonly LoggerMock<TCategoryName> mock;
+            private readonly LoggerMock mock;
 
-            public LoggerMockSetupSequence(LoggerMock<TCategoryName> mock)
+            public LoggerMockSetupSequence(LoggerMock mock)
             {
                 this.mock = mock;
             }
@@ -116,11 +123,11 @@ namespace PosInformatique.Logging.Assertions
             }
         }
 
-        private sealed class LoggerRecorder : ILogger<TCategoryName>
+        private sealed class LoggerRecorder<TCategoryName> : ILogger, ILogger<TCategoryName>
         {
-            private readonly LoggerMock<TCategoryName> mock;
+            private readonly LoggerMock mock;
 
-            public LoggerRecorder(LoggerMock<TCategoryName> mock)
+            public LoggerRecorder(LoggerMock mock)
             {
                 this.mock = mock;
             }
@@ -170,9 +177,9 @@ namespace PosInformatique.Logging.Assertions
 
             private sealed class LogScopeDisposable : IDisposable
             {
-                private readonly LoggerRecorder recorder;
+                private readonly LoggerRecorder<TCategoryName> recorder;
 
-                public LogScopeDisposable(LoggerRecorder recorder)
+                public LogScopeDisposable(LoggerRecorder<TCategoryName> recorder)
                 {
                     this.recorder = recorder;
                 }

--- a/src/Logging.Assertions/LoggerMock{TCategoryName}.cs
+++ b/src/Logging.Assertions/LoggerMock{TCategoryName}.cs
@@ -1,0 +1,46 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="LoggerMock{TCategoryName}.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.Logging.Assertions
+{
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// Allows to mock and retrieve an instance of <see cref="ILogger{TCategoryName}"/>. To mock a <see cref="ILogger{TCategoryName}"/>:
+    /// <list type="bullet">
+    ///     <item>Creates an instance of the <see cref="LoggerMock{TCategoryName}"/>.</item>
+    ///     <item>
+    ///         Setup the expected the calls to the
+    ///         <see cref="ILogger.Log{TState}(LogLevel, EventId, TState, Exception?, Func{TState, Exception?, string})"/> and
+    ///         <see cref="ILogger.BeginScope{TState}(TState)"/> methods.
+    ///     </item>
+    ///     <item>Gets the mocked instance of the <see cref="ILogger{TCategoryName}"/> using the <see cref="object"/> property.</item>
+    ///     <item>Do not forget to call the <see cref="LoggerMock.VerifyLogs"/> method at the end of the unit test to check that there is no missing
+    ///         calls to the <see cref="ILogger"/> methods.</item>
+    /// </list>
+    /// </summary>
+    /// <typeparam name="TCategoryName">The category name of the <see cref="ILogger{TCategoryName}"/> to create.</typeparam>
+    public class LoggerMock<TCategoryName> : LoggerMock
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoggerMock{TCategoryName}"/> class.
+        /// </summary>
+        public LoggerMock()
+        {
+        }
+
+        /// <summary>
+        /// Gets the mocked instance of the <see cref="ILogger{TCategoryName}"/>.
+        /// </summary>
+        public new ILogger<TCategoryName> Object => (ILogger<TCategoryName>)base.Object;
+
+        /// <inheritdoc/>
+        private protected override ILogger CreateRecorder<TIgnored>()
+        {
+            return base.CreateRecorder<TCategoryName>();
+        }
+    }
+}

--- a/src/Logging.Assertions/Logging.Assertions.csproj
+++ b/src/Logging.Assertions/Logging.Assertions.csproj
@@ -10,31 +10,32 @@
     <PackageProjectUrl>https://github.com/PosInformatique/PosInformatique.Logging.Assertions</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
-    1.4.0
-    - Add the ILogger non generic support.
-    
-		1.3.0
-		- Fix an assertion message with the `WithArguments()` method.
-		- Add the support of the `WithException()` followed by the `WithArguments()` method. (fixes #11).
-
-		1.2.0
-		- Improve the BeginScope() to use a delegate to assert complex state objects.
-		- Add a BeginScopeAsDictionary() method to check the state as dictionary string/object (useful for Application Insights logs).
-
-		1.1.0
-		- Add the support to assert the log message template and the parameters.
-
-		1.0.3
-		- Use FluentAssertions 6.0.0 library.
-
-		1.0.2
-		- The library target the .NET Standard 2.0 instead of .NET 6.0.
-
-		1.0.1
-		- Various fixes for the NuGet package description.
-
-		1.0.0
-		- Initial version
+      1.4.0
+      - Add the ILogger non generic support.
+      - Do not hide the initial exception occurred in a BeginScope() block.
+      
+      1.3.0
+      - Fix an assertion message with the `WithArguments()` method.
+      - Add the support of the `WithException()` followed by the `WithArguments()` method. (fixes #11).
+      
+      1.2.0
+      - Improve the BeginScope() to use a delegate to assert complex state objects.
+      - Add a BeginScopeAsDictionary() method to check the state as dictionary string/object (useful for Application Insights logs).
+      
+      1.1.0
+      - Add the support to assert the log message template and the parameters.
+      
+      1.0.3
+      - Use FluentAssertions 6.0.0 library.
+      
+      1.0.2
+      - The library target the .NET Standard 2.0 instead of .NET 6.0.
+      
+      1.0.1
+      - Various fixes for the NuGet package description.
+      
+      1.0.0
+      - Initial version
 	</PackageReleaseNotes>
     <PackageTags>logger log fluent unittest assert assertions logging mock</PackageTags>
   </PropertyGroup>

--- a/src/Logging.Assertions/Logging.Assertions.csproj
+++ b/src/Logging.Assertions/Logging.Assertions.csproj
@@ -10,6 +10,9 @@
     <PackageProjectUrl>https://github.com/PosInformatique/PosInformatique.Logging.Assertions</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+    1.4.0
+    - Add the ILogger non generic support.
+    
 		1.3.0
 		- Fix an assertion message with the `WithArguments()` method.
 		- Add the support of the `WithException()` followed by the `WithArguments()` method. (fixes #11).

--- a/stylecop.json
+++ b/stylecop.json
@@ -2,7 +2,8 @@
   "settings": {
     "documentationRules": {
       "companyName": "P.O.S Informatique",
-      "copyrightText": "Copyright (c) {companyName}. All rights reserved."
+      "copyrightText": "Copyright (c) {companyName}. All rights reserved.",
+      "documentInternalElements": false
     }
   }
 }

--- a/tests/Logging.Assertions.Tests/ExceptionHelperTest.cs
+++ b/tests/Logging.Assertions.Tests/ExceptionHelperTest.cs
@@ -1,0 +1,33 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ExceptionHelperTest.cs" company="P.O.S Informatique">
+//     Copyright (c) P.O.S Informatique. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace PosInformatique.Logging.Assertions.Tests
+{
+    using FluentAssertions;
+    using Xunit;
+
+    public class ExceptionHelperTest
+    {
+        [Fact]
+        public void IsExceptionOnGoing()
+        {
+            ExceptionHelper.IsExceptionOnGoing().Should().BeFalse();
+
+            try
+            {
+                ExceptionHelper.IsExceptionOnGoing().Should().BeFalse();
+
+                throw new Exception("Oups...");
+            }
+            catch
+            {
+                ExceptionHelper.IsExceptionOnGoing().Should().BeTrue();
+            }
+
+            ExceptionHelper.IsExceptionOnGoing().Should().BeFalse();
+        }
+    }
+}

--- a/tests/Logging.Assertions.Tests/LoggerMockTest.cs
+++ b/tests/Logging.Assertions.Tests/LoggerMockTest.cs
@@ -570,6 +570,37 @@ namespace PosInformatique.Logging.Assertions.Tests
             logger.VerifyLogs();
         }
 
+        /// <summary>
+        /// Test the following scenario.
+        /// - BeginScope() block is used.
+        /// - Logs are assert inside this block
+        /// - An exception is throw inside the block.
+        /// => Expected: The exception is thrown, and no assertion exception must be raised in the Dispose() method
+        /// of the log record.
+        /// It will help the developer to know the original exception and not parasited by the exception of the library
+        /// thrown in the Dispose() method.
+        /// </summary>
+        [Fact]
+        public void LogWithException_InsideBeginScope()
+        {
+            var logger = this.CreateLogger();
+            logger.SetupSequence()
+                .LogTrace("Log Trace 1")
+                .BeginScope(new { ScopeLevel = 1, ScopeName = "Scope level 1" })
+                    .LogDebug("Log Debug 2")
+                    .BeginScope(new { ScopeLevel = 2, ScopeName = "Scope level 2" })
+                        .LogInformation("Log Information 3")
+                    .EndScope()
+                    .LogWarning("Log Warning 4")
+                .LogError("Log Error 5");
+
+            var objectToLog = new ObjectToLog(logger.Object);
+
+            objectToLog.Invoking(o => o.InvokeWithExceptionInScope())
+                .Should().ThrowExactly<FormatException>()
+                .WithMessage("The exception");
+        }
+
         protected abstract LoggerMock CreateLogger();
 
         public class Generic : LoggerMockTest
@@ -708,6 +739,23 @@ namespace PosInformatique.Logging.Assertions.Tests
             {
                 this.logger.LogInformation("Log information with parameters {Id}, {Name} and {Object}", 1234, "The name", new { Property = "I am object" });
                 this.logger.LogError("Log error after message template");
+            }
+
+            public void InvokeWithExceptionInScope()
+            {
+                this.logger.LogTrace("Log Trace {0}", 1);
+
+                using (var scope1 = this.logger.BeginScope(new State { ScopeLevel = 1, ScopeName = "Scope level 1" }))
+                {
+                    this.logger.LogDebug("Log Debug {0}", 2);
+
+                    using (var scope2 = this.logger.BeginScope(new State { ScopeLevel = 2, ScopeName = "Scope level 2" }))
+                    {
+                        this.logger.LogInformation("Log Information {0}", 3);
+
+                        throw new FormatException("The exception");
+                    }
+                }
             }
         }
     }

--- a/tests/Logging.Assertions.Tests/LoggerMockTest.cs
+++ b/tests/Logging.Assertions.Tests/LoggerMockTest.cs
@@ -11,12 +11,12 @@ namespace PosInformatique.Logging.Assertions.Tests
     using Xunit;
     using Xunit.Sdk;
 
-    public class LoggerMockTest
+    public abstract class LoggerMockTest
     {
         [Fact]
         public void VerifyAllLogs()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .LogDebug("Log Debug 2")
@@ -34,7 +34,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void VerifyAllLogs_MissingLogs()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .LogDebug("Log Debug 2")
@@ -62,7 +62,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void LogTraceFailed()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace expected")
                 .LogDebug("Log Debug 2")
@@ -80,7 +80,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void LogDebugFailed()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .LogDebug("Log Debug expected")
@@ -98,7 +98,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void LogInformationFailed()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .LogDebug("Log Debug 2")
@@ -116,7 +116,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void LogWarningFailed()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .LogDebug("Log Debug 2")
@@ -134,7 +134,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void LogErrorFailed()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .LogDebug("Log Debug 2")
@@ -154,7 +154,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         {
             var exception = new FormatException("The exception");
 
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogInformation("Log before error")
                 .LogError("Log Error {Id}")
@@ -178,7 +178,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         {
             var exception = new FormatException("The exception");
 
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogInformation("Log before error")
                 .LogError("Log Error {Id}")
@@ -202,7 +202,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         {
             var exception = new FormatException("The exception");
 
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogInformation("Log before error")
                 .LogError("Log Error {Id}")
@@ -224,7 +224,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void LogError_ExpectedExceptionButNoExceptionRaised()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .LogDebug("Log Debug 2")
@@ -243,7 +243,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void LogWrongLevel()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogWarning("Log Trace 1");
 
@@ -257,7 +257,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void LogWithMessageTemplate_DelegateAssertion()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogInformation("Log information with parameters {Id}, {Name} and {Object}")
                     .WithArguments(3, args =>
@@ -278,7 +278,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void LogWithMessageTemplate_DelegateAssertion_WrongExpectedArgumentCount()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogInformation("Log information with parameters {Id}, {Name} and {Object}")
                     .WithArguments(100, args =>
@@ -300,7 +300,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void LogWithMessageTemplate_ParametersAssertion()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogInformation("Log information with parameters {Id}, {Name} and {Object}")
                     .WithArguments(1234, "The name", new { Property = "I am object" })
@@ -316,7 +316,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void LogWithMessageTemplate_ParametersAssertion_WrongExpectedArgumentCount()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogInformation("Log information with parameters {Id}, {Name} and {Object}")
                     .WithArguments(1, 2, 3, 4, 5, 6, 7, "The name", new { Property = "I am object" })
@@ -332,7 +332,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void LoggerCalledToManyTimes()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .LogDebug("Log Debug 2")
@@ -348,7 +348,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void VerifyAllLogs_WithScopes_ObjectAssertion()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .BeginScope(new { ScopeLevel = 1, ScopeName = "Scope level 1" })
@@ -370,7 +370,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void VerifyAllLogs_WithScopes_DictionaryAssertion()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .BeginScopeAsDictionary(new { ScopeLevel = 1, ScopeName = "Scope level 1" })
@@ -392,7 +392,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void VerifyAllLogs_WithScopes_DelegateAssertion()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .BeginScope<State>(state =>
@@ -422,7 +422,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void BeginScope_DelegateAssertion_WrongExpectedStateType()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .BeginScope<DateTime>(state =>
@@ -440,7 +440,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void BeginScope_AnonymousObjectAssertion_DifferentProperty()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .BeginScope(new { DifferentProperty = "Other value" });
@@ -455,7 +455,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void BeginScope_Expected()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .LogDebug("Log Debug 2");
@@ -470,7 +470,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void BeginScope_EndScopeExpected()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .BeginScope(new { ScopeLevel = 1, ScopeName = "Scope level 1" })
@@ -491,7 +491,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void BeginScopeAsDictionary_ExpectedMissingProperty()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .BeginScopeAsDictionary(new { ScopeLevel = 1, ScopeName = "Scope level 1", ExpectedProperty = "The expected value" });
@@ -506,7 +506,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void BeginScopeAsDictionary_ExpectedLessProperties()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogTrace("Log Trace 1")
                 .BeginScopeAsDictionary(new { ScopeLevel = 1 });
@@ -521,7 +521,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         [Fact]
         public void IsEnabled_NotSupported()
         {
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
 
             logger.Object.Invoking(l => l.IsEnabled(LogLevel.Debug))
                 .Should().ThrowExactly<NotSupportedException>()
@@ -533,7 +533,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         {
             var exception = new FormatException("The exception");
 
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogError("Log Error")
                     .WithException(exception)
@@ -557,7 +557,7 @@ namespace PosInformatique.Logging.Assertions.Tests
         {
             var exception = new FormatException("The exception");
 
-            var logger = new LoggerMock<ObjectToLog>();
+            var logger = this.CreateLogger();
             logger.SetupSequence()
                 .LogError("Log Error")
                     .WithException(exception)
@@ -570,6 +570,26 @@ namespace PosInformatique.Logging.Assertions.Tests
             logger.VerifyLogs();
         }
 
+        protected abstract LoggerMock CreateLogger();
+
+        public class Generic : LoggerMockTest
+        {
+            [Fact]
+            public void Object()
+            {
+                var generic = new LoggerMock<ObjectToLog>();
+
+                generic.Object.Should().BeSameAs(((LoggerMock)generic).Object);
+            }
+
+            protected override LoggerMock CreateLogger() => new LoggerMock<ObjectToLog>();
+        }
+
+        public class NonGeneric : LoggerMockTest
+        {
+            protected override LoggerMock CreateLogger() => new LoggerMock();
+        }
+
         private class State
         {
             public int ScopeLevel { get; set; }
@@ -579,9 +599,9 @@ namespace PosInformatique.Logging.Assertions.Tests
 
         private class ObjectToLog
         {
-            private readonly ILogger<ObjectToLog> logger;
+            private readonly ILogger logger;
 
-            public ObjectToLog(ILogger<ObjectToLog> logger)
+            public ObjectToLog(ILogger logger)
             {
                 this.logger = logger;
             }


### PR DESCRIPTION
- Do not throw an exception in the Dispose() block of BeginScope() if an exception is ongoing (fixes #13).
- Add the non generic ILogger mock support (fixes #14).